### PR TITLE
feat:Implementation for when a channel is clicked#39

### DIFF
--- a/src/components/chat/chat.tsx
+++ b/src/components/chat/chat.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { useAtom } from "jotai";
+import { channelAtom } from "@/state/channel";
 import ChatHeader from "@/components/chat/chatHeader";
 import ChatMessage from "@/components/chat/chatMessage";
 import { IcBaselineAddCircleOutline } from "@/components/icones/icBaselineAddCircleOutline";
@@ -6,10 +10,12 @@ import { IcBaselineGif } from "@/components/icones/icBaselineGif";
 import { IcOutlineCardGiftcard } from "@/components/icones/icOutlineCardGiftcard";
 
 export default function Chat() {
+  const [channel] = useAtom(channelAtom);
+
   return (
     <div className="flex flex-col grow bg-[#33363d]">
       {/* chatHeader */}
-      <ChatHeader />
+      <ChatHeader channel={channel} />
       {/* chatMessage */}
       <div className="grow">
         <ChatMessage />

--- a/src/components/chat/chatHeader.tsx
+++ b/src/components/chat/chatHeader.tsx
@@ -4,14 +4,21 @@ import { IcBaselinePeopleAlt } from "@/components/icones/icBaselinePeopleAlt";
 import { IcBaselinePushPin } from "@/components/icones/icBaselinePushPin";
 import { IcBaselineSend } from "@/components/icones/icBaselineSend";
 import { Input } from "@/components/ui/input";
+import { Channel } from "@/types/channel";
 
-export default function ChatHeader() {
+type Props = {
+  channel: Channel | null;
+};
+
+export default function ChatHeader(props: Props) {
+  const { channel } = props;
+
   return (
     <div className="flex items-center justify-between w-full pt-2">
       <div className="pl-4">
         <h3 className="text-white">
           <span className="text-[#7b7c85] pr-2">#</span>
-          Udemy
+          {channel ? channel.name : "No channel selected"}
         </h3>
       </div>
 

--- a/src/components/sidebar/sidebar.tsx
+++ b/src/components/sidebar/sidebar.tsx
@@ -62,15 +62,15 @@ export default function Sidebar({ user }: { user: UserMetadata | undefined }) {
         <div className="p-3">
           <div className="text-white flex justify-between items-center mt-1">
             <div className="flex items-center">
-              <RadixIconsChevronDown />
-              <h4>プログラミングチャンネル</h4>
+              <RadixIconsChevronDown className="mr-1" />
+              <h4>Programming Channel</h4>
             </div>
             <RadixIconsPlus className="cursor-pointer" onClick={addChannel} />
           </div>
 
           <div className="sidebarChennelList">
             {channels.map((channel) => (
-              <SidebarChannel id={channel.id} channel={channel} key={channel.id} />
+              <SidebarChannel channel={channel} key={channel.id} />
             ))}
           </div>
 

--- a/src/components/sidebar/sidebarChannel.tsx
+++ b/src/components/sidebar/sidebarChannel.tsx
@@ -1,15 +1,17 @@
+import { useAtom } from "jotai";
+import { channelAtom } from "@/state/channel";
 import { Channel } from "@/types/channel";
 
 type Props = {
-  id: number;
   channel: Channel;
 };
 
 export default function SidebarChannel(props: Props) {
-  const { id, channel } = props;
+  const { channel } = props;
+  const [, setChannel] = useAtom(channelAtom);
 
   return (
-    <div className="pl-5 mt-1">
+    <div className="pl-5 mt-1" onClick={() => setChannel(channel)}>
       <h4 className="text-[#7b7c85] flex items-center p-1 cursor-pointer hover:text-white hover:bg-[#33363d] hover:rounded-md">
         <span className="text-xl pr-2">#</span>
         {channel.name}

--- a/src/state/channel.ts
+++ b/src/state/channel.ts
@@ -1,0 +1,4 @@
+import { atom } from "jotai";
+import { Channel } from "@/types/channel";
+
+export const channelAtom = atom<Channel | null>(null);


### PR DESCRIPTION
## やったこと
jotaiを使ってサイドバーチャンネルをクリックしたときにそのチャンネル情報を保持し、
チャットコンポーネントはその情報を取ってきて子コンポーネントに渡すように実装しました！

以下参照です！
https://jotai.org/docs/core/use-atom
[Implementation for when a channel is clicked#39](https://github.com/zksytmkn/discord-replica/issues/39)